### PR TITLE
#2384: Update Ballerina.toml, POM, helm chart and install script versions for 1.3.2 release

### DIFF
--- a/consolidator/Ballerina.toml
+++ b/consolidator/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "mosip"
 name = "consolidatorService"
-version = "1.3.2-rc.1"
+version = "1.3.2-SNAPSHOT"
 
 [build-options]
 observabilityIncluded = true
@@ -10,5 +10,5 @@ observabilityIncluded = true
 modules = ["inittopic"]
 groupId = "io.mosip"
 artifactId = "kafka-admin-client"
-version = "1.3.2-rc.1"
-path = "kafka-admin-client/target/kafka-admin-client-1.3.2-rc.1.jar"
+version = "1.3.2-SNAPSHOT"
+path = "kafka-admin-client/target/kafka-admin-client-1.3.2-SNAPSHOT.jar"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=websub
-CHART_VERSION=1.3.2-rc.1-develop
+CHART_VERSION=1.3.2-develop
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/helm/websub-consolidator/Chart.yaml
+++ b/helm/websub-consolidator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: websub-consolidator
 description: A Helm chart for Websub Cconsolidator
 type: application
-version: 1.3.2-rc.1-develop
+version: 1.3.2-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/websub-consolidator/values.yaml
+++ b/helm/websub-consolidator/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/consolidator-websub-service
-  tag: 1.3.2-rc.1
+  repository: mosipqa/consolidator-websub-service
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/helm/websub/Chart.yaml
+++ b/helm/websub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: websub
 description: A Helm chart for Websub service
 type: application
-version: 1.3.2-rc.1-develop
+version: 1.3.2-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/websub/values.yaml
+++ b/helm/websub/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/websub-service
-  tag: 1.3.2-rc.1
+  repository: mosipqa/websub-service
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/hub/Ballerina.toml
+++ b/hub/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "mosip"
 name = "kafkaHub"
-version = "1.3.2-rc.1"
+version = "1.3.2-SNAPSHOT"
 
 [build-options]
 observabilityIncluded = true
@@ -10,5 +10,5 @@ observabilityIncluded = true
 modules = ["inittopic"]
 groupId = "io.mosip"
 artifactId = "kafka-admin-client"
-version = "1.3.2-rc.1"
-path = "kafka-admin-client/target/kafka-admin-client-1.3.2-rc.1.jar"
+version = "1.3.2-SNAPSHOT"
+path = "kafka-admin-client/target/kafka-admin-client-1.3.2-SNAPSHOT.jar"

--- a/kafka-admin-client/pom.xml
+++ b/kafka-admin-client/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.mosip</groupId>
 	<artifactId>kafka-admin-client</artifactId>
-	<version>1.3.2-rc.1</version>
+	<version>1.3.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>kafka-admin-client</name>


### PR DESCRIPTION
…r 1.3.2 QA release

Convert rc versions to SNAPSHOT in kafka-admin-client/pom.xml and both Ballerina.toml files, update Chart.yaml and install.sh chart_version to 1.3.2-develop, and point values.yaml image repositories to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated service and package versions to the `1.3.2-SNAPSHOT` development line.
  - Advanced deployment charts to the `1.3.2-develop` version.
  - Updated WebSub and WebSub consolidator deployments to use the `1.3.x` container image series.
  - Switched deployment images to the QA image repositories for continued development and validation.
  - No user-facing functionality or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->